### PR TITLE
Add explicit format sarif to the CLI run

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,7 @@ runs:
       shell: bash
       run: |
         echo "Running the tool"
-        /tmp/codacy-cli-v2 analyze -t ${{inputs.tool}} -o ${{inputs.sarif_file_path}}
+        /tmp/codacy-cli-v2 analyze -t ${{inputs.tool}} --format sarif -o ${{inputs.sarif_file_path}}
         echo "Tool run complete"
     - name: "Upload the results"
       shell: bash


### PR DESCRIPTION
This guarantees that the same behaviour of keep outputting in SARIF
The CLI will change to no longer be SARIF by default when outputting to a file